### PR TITLE
Deduplicate paths for JARs #2

### DIFF
--- a/streams0/streams9.js
+++ b/streams0/streams9.js
@@ -349,6 +349,8 @@ function getLibraryTableXML(library) {
 
 	var binaryPaths = getLibraryJarPaths(library);
 
+	binaryPaths = Array.from(new Set(binaryPaths));
+
 	if (binaryPaths.length > 0) {
 		libraryTableXML.push('<CLASSES>');
 		Array.prototype.push.apply(libraryTableXML, binaryPaths.map(getLibraryRootElement));


### PR DESCRIPTION
Hi @holatuwol,

fixing #2.

I'm not sure this is the right fix at the right place, but at least the idea :)

Thanks.

For io.netty:netty-codec-http2:4.1.0.Final it trims down the array from 151920 to 203 items.