### PR TITLE
Revert "Absolute path to find" for Windows compatibility

### DIFF
--- a/streams9/streams8.js
+++ b/streams9/streams8.js
@@ -125,7 +125,7 @@ function generateFileListCache(cachePath) {
 	var fileList = [];
 
 	try {
-		fileList = execFileSync('/usr/bin/find', args, options).toString().split('\n');
+		fileList = execFileSync('find', args, options).toString().split('\n');
 	}
 	catch (e) {
 		console.error(e);


### PR DESCRIPTION
Hi @holatuwol ,
I'd like to revert this change as it breaks Windows compatibility.
(module .iml-s are not created)

Here is the output of running ij:
```
[13:45:54] Running npm to update script dependencies
added 4 packages from 1 contributor, removed 1 package, moved 1 package and audited 49 packages in 1.127s
found 2 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
[13:46:02] Building /c/git/71x/71x ls-files cache to speed up directory scanning
[13:46:14] Missing clone of https://github.com/liferay/liferay-binaries-cache-2017
which: no mvn in (/c/Users/balazssk/bin:/mingw64/bin:/usr/local/bin:/usr/bin:/bin:/mingw64/bin:/usr/bin:/c/Users/balazssk/bin:/c/Program Files (x86)/Common Files/Oracle/Java/javapath:/c/Windows/system32:/c/Windows:/c/Windows/System32/Wbem:/c/Windows/System32/WindowsPowerShell/v1.0:/c/Windows/System32/OpenSSH:/c/Program Files (x86)/Intel/Intel(R) Management Engine Components/DAL:/c/Program Files/Intel/Intel(R) Management Engine Components/DAL:/cmd:/c/dev/java/jdk8u212/bin:/c/dev/ant/bin:/c/dev/nodejs:/c/Program Files (x86)/GitExtensions:/c/Users/balazssk/.jpm/windows/bin:/c/Users/balazssk/AppData/Local/Microsoft/WindowsApps:/c/Users/balazssk/AppData/Roaming/npm:/usr/bin/vendor_perl:/usr/bin/core_perl)
Maven is not available in the path, dependency libraries will be missing
[1:46:15 PM] Scanning C:/git/71x/71x ls-files cache for legacy plugins
[1:46:15 PM] Located 0 legacy plugins folders in C:/git/71x/71x
[1:46:15 PM] Scanning C:\git\71x\71x\modules ls-files cache for modules
[1:46:15 PM] Located 0 modules folders in C:/git/71x/71x
[1:46:15 PM] Extracting metadata from module build files
[1:46:15 PM] Extracting metadata from root level folder build files
[1:46:15 PM] Extracting metadata from legacy plugin build files
[1:46:15 PM] Checking for Git roots, Gradle caches, and Maven caches
{ Error: spawnSync /usr/bin/find ENOENT
    at Object.spawnSync (internal/child_process.js:1002:20)
    at spawnSync (child_process.js:614:24)
    at execFileSync (child_process.js:642:13)
    at generateFileListCache (C:\git\liferay-intellij\streams9\streams8.js:128:14)
    at createProjectWorkspace (C:\git\liferay-intellij\streams0\streams0.js:161:3)
    at scanProject (C:\git\liferay-intellij\streams0\index.js:308:2)
    at Object.createProject (C:\git\liferay-intellij\streams0\index.js:29:2)
    at Object.<anonymous> (C:\git\liferay-intellij\bin\run.js:27:18)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
  errno: 'ENOENT',
  code: 'ENOENT',
  syscall: 'spawnSync /usr/bin/find',
  path: '/usr/bin/find',
  spawnargs: [ '-L', '.', '-name', '*.jar', '-o', '-name', '*.pom' ],
  error: [Circular],
  status: null,
  signal: null,
  output: null,
  pid: 0,
  stdout: null,
  stderr: null }
[1:46:15 PM] Remembering 0 artifacts found in C:\Users\balazssk\.gradle\caches\modules-2\files-2.1
[1:46:15 PM] Analyzing existing IntelliJ breakpoints
[1:46:15 PM] Processing dependency versions
[1:46:15 PM] Processing BOM dependencies
[1:46:15 PM] BOM dependencies have been downloaded
[1:46:15 PM] Processing missing dependencies
[1:46:15 PM] Missing dependencies have been downloaded
[1:46:15 PM] Generating IntelliJ workspace
```

In my case a find is at "c:\Program Files\Git\usr\bin\find"

What do you think?

Thanks,
Balázs