### PR TITLE
Use absolute path for the file path

### DIFF
--- a/streams7/streams6.js
+++ b/streams7/streams6.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var highland = require('highland');
+var path = require('path');
 var streams2 = require('../streams2/streams2');
 var streams3 = require('../streams4/streams3');
 var streams5 = require('../streams6/streams5');
@@ -254,7 +255,7 @@ function saveContent(file) {
 		}
 	}
 
-	fs.writeFileSync(file.name, splitContent.join('\n'));
+	fs.writeFileSync(path.resolve(file.name), splitContent.join('\n'));
 };
 
 exports.createProjectWorkspace = createProjectWorkspace;


### PR DESCRIPTION
Hi @holatuwol ,

When using the feature to specify additional folders for blade projects:
```
ij /path/to/folder1 /path/to/folder2 /path/to/folder3
```   

I sometimes encounter the error:
```
node:internal/fs/utils:344
    throw err;
    ^

Error: ENOENT: no such file or directory, open '../../../../../../../../tmp/sb/modules/abc/abc-api/abc-api.iml'
    at Object.openSync (node:fs:585:3)
    at Object.writeFileSync (node:fs:2153:35)
    at saveContent (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams7/streams6.js:257:5)
    at /Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1559:13
    at Stream.s._send (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1285:9)
    at Stream.write (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1375:18)
    at Stream._send (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:761:26)
    at push (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1250:19)
    at /Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1719:13
    at Stream.s._send (/Users/liferay/Liferay/development/repos/holatuwol/liferay-intellij/streams0/node_modules/highland/lib/index.js:1285:9) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '../../../../../../../../tmp/sb/modules/abc/abc-api/abc-api.iml'
```

The proposed fix resolves this by using the absolute path instead of relative path.

Feel free to let me know if you have any questions.
Thanks!